### PR TITLE
add docs on the ASmap health check in Core

### DIFF
--- a/content/bitcoin-core.md
+++ b/content/bitcoin-core.md
@@ -30,7 +30,7 @@ If an ASmap is provided when starting bitcoind, a health check will run during s
 ```
 ASMap Health Check: 32546 clearnet peers are mapped to 3127 ASNs with 113 peers being unmapped
 ```
-Meaning, there are valid AS entries for 32546 of one's peers, and 113 peers don't have a valid AS entry in the provided ASmap.
+Meaning, there are AS mappings available for the IPs of 32546 of our peers. 113 peers don't have an AS mapping for their IP in the provided ASmap.
 
 ## TODO
 

--- a/content/bitcoin-core.md
+++ b/content/bitcoin-core.md
@@ -26,7 +26,7 @@ If you generate a file yourself, you must compress it before passing it to `bitc
 
 #### ASmap Health Check
 
-If an ASmap is provided when starting bitcoind, a health check will run every 24 hours and log the level of coverage the ASmap can validate for one's current peer set. For example:
+If an ASmap is provided when starting bitcoind, a health check will run during startup and then every 24 hours. It logs the level of coverage the ASmap provides for all the clearnet addresses known to our node. For example:
 ```
 ASMap Health Check: 32546 clearnet peers are mapped to 3127 ASNs with 113 peers being unmapped
 ```

--- a/content/bitcoin-core.md
+++ b/content/bitcoin-core.md
@@ -24,6 +24,14 @@ You can choose to generate an ASmap file yourself. [Kartograf](https://github.co
 
 If you generate a file yourself, you must compress it before passing it to `bitcoind`. [asmap-tool](https://github.com/bitcoin/bitcoin/tree/master/contrib/asmap) is a Python script to help encode/compress an ASmap file. `asmap-tool` is included in the Bitcoin Core repository.
 
+#### ASmap Health Check
+
+If an ASmap is provided when starting bitcoind, a health check will run every 24 hours and log the level of coverage the ASmap can validate for one's current peer set. For example:
+```
+ASMap Health Check: 32546 clearnet peers are mapped to 3127 ASNs with 113 peers being unmapped
+```
+Meaning, there are valid AS entries for 32546 of one's peers, and 113 peers don't have a valid AS entry in the provided ASmap.
+
 ## TODO
 
 See the project [tracking issue](https://github.com/bitcoin/bitcoin/issues/28794) on GitHub.


### PR DESCRIPTION
Testing on my local node, how did I end up with 32k peers validated? This is the peers our node knows about, but bitcoind only connects to a subset, is that right?
first part of #10 